### PR TITLE
Fix External Controller 

### DIFF
--- a/src/Nudes.Identity/Features/ExternalController.cs
+++ b/src/Nudes.Identity/Features/ExternalController.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using Nudes.Identity.Features.Users;
 using Nudes.Identity.Options;
 
@@ -31,14 +32,14 @@ namespace Nudes.Identity
             IIdentityServerInteractionService interaction,
             IClientStore clientStore,
             IEventService events,
-            NudesIdentityOptions options,
+            IOptions<NudesIdentityOptions> options,
             INudesIdentityUserStorage nudesIdentityUserStorage
             )
         {
             this.interaction = interaction;
             this.clientStore = clientStore;
             this.events = events;
-            this.options = options;
+            this.options = options.Value;
             this.nudesIdentityUserStorage = nudesIdentityUserStorage;
         }
 


### PR DESCRIPTION
When using login with external provider an exception is throw because the services container can't find a NudesIdentityOptions.
This PR changes NudesIdentityOptions dependency on the ExternalController.cs to IOptions<NudesIdentityOptions>